### PR TITLE
Realsense nodelet crash - nodelet::Loader::Impl

### DIFF
--- a/nodelet/src/callback_queue_manager.cpp
+++ b/nodelet/src/callback_queue_manager.cpp
@@ -123,7 +123,8 @@ void CallbackQueueManager::removeQueue(const CallbackQueuePtr& queue)
   boost::mutex::scoped_lock lock(queues_mutex_);
   ROS_ASSERT(queues_.find(queue.get()) != queues_.end());
 
-  queues_.erase(queue.get());
+  if (queues_.find(queue.get()) != queues_.end())
+    queues_.erase(queue.get());
 }
 
 void CallbackQueueManager::callbackAdded(const CallbackQueuePtr& queue)


### PR DESCRIPTION
The `nodelet::detail::CallbackQueueManager::removeQueue` removes an entry from the list of queues without checking first that the entry exists in the queue. When that happens, the underlying C++ library throws an object not found exception aborting the process.
This change only adds a test to make we only remove a queue that exists.